### PR TITLE
Fix Gradle Build Issue by Updating copyDistribution Task Configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins.withType(JavaPlugin).configureEach {
 
 // Copy the Java modules, run script and JAR in the distribution directory
 tasks.register("copyDistribution", Copy) {
-    from configurations.default
+    from configurations.runtimeClasspath
     from tasks.named('jar')
     from layout.projectDirectory.file('assets/run.sh')
     into layout.buildDirectory.dir('distribution')


### PR DESCRIPTION
This PR resolves a build failure in the Gradle copyDistribution task caused by attempting to resolve the default configuration, which is marked as canBeResolved=false in newer versions of Gradle (8.x).
**Changes**:

- Replaced `configurations.default` with `configurations.runtimeClasspath` in the `copyDistribution` task to ensure that a resolvable configuration is used.
- The `runtimeClasspath` configuration includes all runtime dependencies, ensuring that the correct dependencies and artifacts are copied to the distribution directory.

This change ensures compatibility with Gradle 8.10.2 and prevents build failures related to non-resolvable configurations.